### PR TITLE
added the notification message model object

### DIFF
--- a/src/model/NotificationMessage.java
+++ b/src/model/NotificationMessage.java
@@ -1,0 +1,51 @@
+package model;
+
+import java.util.Date;
+
+import FIPA.DateTime;
+import jade.lang.acl.ACLMessage;
+
+public class NotificationMessage extends ACLMessage {
+	
+	private int units;
+	private int hours; 
+	private DateTime on;
+	
+	public NotificationMessage(int units,int hours, DateTime on){
+		super(ACLMessage.INFORM);
+		this.setUnits(units);
+		this.setHours(hours);
+		this.setOn(on);
+	}
+	
+	@Override
+	public String getContent(){
+		return getUnits() + ":" + getHours() + ":" + getOn().hour;
+		
+	}
+
+	private int getUnits() {
+		return units;
+	}
+
+	private void setUnits(int units) {
+		this.units = units;
+	}
+
+	private int getHours() {
+		return hours;
+	}
+
+	private void setHours(int hours) {
+		this.hours = hours;
+	}
+
+	private DateTime getOn() {
+		return on;
+	}
+
+	private void setOn(DateTime on) {
+		this.on = on;
+	}
+	
+}


### PR DESCRIPTION
From API “The couple of methods setContentObject() and
getContentObject() allow to send serialized Java objects over the
content of an ACLMessage. These method are not strictly FIPA compliant
so their usage is not encouraged”

Not sure how else to serialise the object, so I created a object that
inherit an ACLMessage of type INFORM. Did the serialisation on the
getContent